### PR TITLE
Add footer and main menu locations to menu endpoint

### DIFF
--- a/src/admin/class-menus.php
+++ b/src/admin/class-menus.php
@@ -54,6 +54,8 @@ class Menus {
 			[
 				'owace-this-website-menu' => esc_html__( 'OpenWoo - This website', 'openwoo-app-content-editor' ),
 				'owace-quick-links-menu'  => esc_html__( 'OpenWoo - Quick links', 'openwoo-app-content-editor' ),
+				'owace-footer-menu'       => esc_html__( 'OpenWoo - Footer', 'openwoo-app-content-editor' ),
+				'owace-main-menu'         => esc_html__( 'OpenWoo - Main', 'openwoo-app-content-editor' ),
 			]
 		);
 	}

--- a/src/rest_api/class-owace-controller.php
+++ b/src/rest_api/class-owace-controller.php
@@ -433,7 +433,7 @@ class OWACE_Controller extends \WP_REST_Posts_Controller {
 	 */
 	public function get_menus() {
 		$data['data'] = [];
-		foreach ( [ 'owace-this-website-menu', 'owace-quick-links-menu' ] as $location_slug ) {
+		foreach ( [ 'owace-this-website-menu', 'owace-quick-links-menu', 'owace-footer-menu', 'owace-main-menu' ] as $location_slug ) {
 			$data['data'][ $location_slug ] = $this->get_menu_item_by_slug( $location_slug );
 		}
 


### PR DESCRIPTION
Register two additional OpenWoo nav menu locations (owace-footer-menu, owace-main-menu) and include them in the public menu REST endpoint so they are returned alongside the existing "this website" and "quick links" menus.